### PR TITLE
Add separate makefiles for linux / OSX. Add sed fix to tleupdate.

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -1,0 +1,60 @@
+# Compiling flags
+CFLAGS = -O3
+
+# Linking flags
+LFLAGS = -lcpgplot -lpgplot -lX11 -lpng -lm -lgsl -lgslcblas
+
+# Compiler
+CC = gcc
+
+# Installation
+INSTALL_PROGRAM = install -m 557
+prefix = /usr/local
+exec_prefix = $(prefix)
+bindir = $(exec_prefix)/bin
+
+all:
+	make rfedit rfplot rffft rfpng rffit rffind
+
+rffit: rffit.o sgdp4.o satutl.o deep.o ferror.o dsmin.o simplex.o versafit.o
+	gfortran -o rffit rffit.o sgdp4.o satutl.o deep.o ferror.o dsmin.o simplex.o versafit.o $(LFLAGS)
+
+rfpng: rfpng.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o
+	gfortran -o rfpng rfpng.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o $(LFLAGS)
+
+rfedit: rfedit.o rfio.o rftime.o
+	$(CC) -o rfedit rfedit.o rfio.o rftime.o -lm
+
+rffind: rffind.o rfio.o rftime.o
+	$(CC) -o rffind rffind.o rfio.o rftime.o -lm
+
+rftrack: rftrack.o rfio.o rftime.o rftrace.o sgdp4.o satutl.o deep.o ferror.o
+	$(CC) -o rftrack rftrack.o rfio.o rftime.o rftrace.o sgdp4.o satutl.o deep.o ferror.o -lm
+
+rfplot: rfplot.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o 
+	gfortran -o rfplot rfplot.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o $(LFLAGS)
+
+rffft: rffft.o rftime.o
+	$(CC) -o rffft rffft.o rftime.o -lfftw3f -lm
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f *.o
+	rm -f *~
+
+install:
+	$(INSTALL_PROGRAM) rffit $(DESTDIR)$(bindir)/rffit
+	$(INSTALL_PROGRAM) rfpng $(DESTDIR)$(bindir)/rfpng
+	$(INSTALL_PROGRAM) rfedit $(DESTDIR)$(bindir)/rfedit
+	$(INSTALL_PROGRAM) rffind $(DESTDIR)$(bindir)/rffind
+	$(INSTALL_PROGRAM) rfplot $(DESTDIR)$(bindir)/rfplot
+	$(INSTALL_PROGRAM) rffft $(DESTDIR)$(bindir)/rffft
+
+uninstall:
+	$(RM) $(DESTDIR)$(bindir)/rffit
+	$(RM) $(DESTDIR)$(bindir)/rfpng
+	$(RM) $(DESTDIR)$(bindir)/rfedit
+	$(RM) $(DESTDIR)$(bindir)/rffind
+	$(RM) $(DESTDIR)$(bindir)/rfplot
+	$(RM) $(DESTDIR)$(bindir)/rffft

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -1,0 +1,73 @@
+#
+#	STRF MacOSX Makefile
+#
+#	Mark Jessop 2018-12
+#
+
+# Your Prefix.
+# If running Macports, this will likely be /opt/local
+# if using Homebrew, then probably /usr/local/
+prefix = /opt/local
+
+# Compiling flags
+CFLAGS = -O3 -I$(prefix)/include
+
+# Linking flags
+LFLAGS = -L$(prefix)/lib -lcpgplot -lpgplot -lX11 -lpng -lm -lgsl -lgslcblas
+
+# Compiler
+# NOTE: STRF will not compile or link correctly with the system gcc (which is actually clang)
+# It's best to build with gcc provided by Macports or Homebrew
+# Under Macports, this is provided as gcc-mp-7, as below, on Homebrew this may be different.
+CC = $(prefix)/bin/gcc-mp-7
+
+# Installation
+INSTALL_PROGRAM = install -m 557
+exec_prefix = $(prefix)
+bindir = $(exec_prefix)/bin
+
+all:
+	make rfedit rfplot rffft rfpng rffit rffind
+
+rffit: rffit.o sgdp4.o satutl.o deep.o ferror.o dsmin.o simplex.o versafit.o
+	$(CC) -o rffit rffit.o sgdp4.o satutl.o deep.o ferror.o dsmin.o simplex.o versafit.o $(LFLAGS)
+
+rfpng: rfpng.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o
+	$(CC) -o rfpng rfpng.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o $(LFLAGS)
+
+rfedit: rfedit.o rfio.o rftime.o
+	$(CC) -o rfedit rfedit.o rfio.o rftime.o -lm
+
+rffind: rffind.o rfio.o rftime.o
+	$(CC) -o rffind rffind.o rfio.o rftime.o -lm
+
+rftrack: rftrack.o rfio.o rftime.o rftrace.o sgdp4.o satutl.o deep.o ferror.o
+	$(CC) -o rftrack rftrack.o rfio.o rftime.o rftrace.o sgdp4.o satutl.o deep.o ferror.o -lm
+
+rfplot: rfplot.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o 
+	$(CC) -o rfplot rfplot.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o $(LFLAGS)
+
+rffft: rffft.o rftime.o
+	$(CC) -o rffft rffft.o rftime.o -lfftw3f -lm $(LFLAGS)
+
+.PHONY: clean install uninstall
+
+clean:
+	rm -f *.o
+	rm -f *~
+
+install:
+	$(INSTALL_PROGRAM) rffit $(DESTDIR)$(bindir)/rffit
+	$(INSTALL_PROGRAM) rfpng $(DESTDIR)$(bindir)/rfpng
+	$(INSTALL_PROGRAM) rfedit $(DESTDIR)$(bindir)/rfedit
+	$(INSTALL_PROGRAM) rffind $(DESTDIR)$(bindir)/rffind
+	$(INSTALL_PROGRAM) rfplot $(DESTDIR)$(bindir)/rfplot
+	$(INSTALL_PROGRAM) rffft $(DESTDIR)$(bindir)/rffft
+
+uninstall:
+	$(RM) $(DESTDIR)$(bindir)/rffit
+	$(RM) $(DESTDIR)$(bindir)/rfpng
+	$(RM) $(DESTDIR)$(bindir)/rfedit
+	$(RM) $(DESTDIR)$(bindir)/rffind
+	$(RM) $(DESTDIR)$(bindir)/rfplot
+	$(RM) $(DESTDIR)$(bindir)/rffft

--- a/data/sites.txt
+++ b/data/sites.txt
@@ -51,6 +51,7 @@
 8536 TL   36.8479  -76.5010      4    Tim Luton
 8539 SN   39.4707  -79.3388    839    Steve Newcomb
 8597 TB  -34.9638  138.6333    100    Tony Beresford 
+8650 QI  -34.7207  138.6928     80    Mark Jessop
 8600 PC  -32.9770  151.6477     18    Paul Camilleri
 0699 PC  -14.4733  132.2369    108    Paul Camilleri
 8730 EC   30.3086  -97.7279    150    Ed Cannon

--- a/tleupdate
+++ b/tleupdate
@@ -18,8 +18,18 @@ wget --post-data=$ST_LOGIN --cookies=on --keep-session-cookies --save-cookies=/t
 wget  --keep-session-cookies --load-cookies=/tmp/cookies.txt 'https://www.space-track.org/basicspacedata/query/class/tle_latest/ORDINAL/1/EPOCH/%3Enow-30/format/3le' -O catalog.tle
 dos2unix catalog.tle
 
+# Determine if we have gsed on our system, which probably means that the regular 'sed'
+# is BSD sed, which has a differnet syntax. Use GNU sed instead...
+gsed_exists=$(which gsed)
+if [ -n "$gsed_exists" ]; then
+	SED=gsed
+	echo "Using GSED"
+else
+	SED=sed
+fi
+
 # Fix missing leading zeros
-sed -i -e "s/^1     /1 0000/g" -e "s/^2     /2 0000/g" -e "s/^1    /1 000/g" -e "s/^2    /2 000/g" -e "s/^1   /1 00/g" -e "s/^2   /2 00/g" -e "s/^1  /1 0/g" -e "s/^2  /2 0/g" catalog.tle
+$SED -i -e "s/^1     /1 0000/g" -e "s/^2     /2 0000/g" -e "s/^1    /1 000/g" -e "s/^2    /2 000/g" -e "s/^1   /1 00/g" -e "s/^2   /2 00/g" -e "s/^1  /1 0/g" -e "s/^2  /2 0/g" catalog.tle
 cp catalog.tle ${DATE}_catalog.txt
 rm login
 


### PR DESCRIPTION
This PR separates out the makefiles so there is a separate one for Linux and OSX. This probably isn't the best solution for handling OSX/Linux differences, but does work. I'll try and produce a cleaner solution in the future.
Anyway, this allows building of the strf utilities under OSX (only tested using Macports, should be OK with Homebrew).

I've also added a small change to tleupdate so that it will use gsed instead of sed, if it exists. This is because 'sed' under OSX is the BSD sed, which has different syntax to GNU sed. Thankfully GNU sed is available via Macports :-)