### PR TITLE
Prevent under and overflow of selection buffer

### DIFF
--- a/rfplot.c
+++ b/rfplot.c
@@ -384,11 +384,15 @@ int main(int argc,char *argv[])
 
     // Select start
     if (c=='s') {
-      sel.x[isel]=x;
-      sel.y[isel]=y;
-      isel++;
-      sel.n=isel;
-      redraw=1;
+      if (sel.n < NMAX) {
+        sel.x[isel]=x;
+        sel.y[isel]=y;
+        isel++;
+        sel.n=isel;
+        redraw=1;
+      } else {
+        printf("Maximum number of %i selection point reached.\n", NMAX);
+      }
       continue;
     }
 
@@ -457,9 +461,11 @@ int main(int argc,char *argv[])
 
     // Undo
     if (c=='u') {
-      isel--;
-      sel.n=isel;
-      redraw=1;
+      if (sel.n > 0) {
+        isel--;
+        sel.n=isel;
+        redraw=1;
+      }
     }
 
     // Increase

--- a/rfplot.c
+++ b/rfplot.c
@@ -55,7 +55,7 @@ int main(int argc,char *argv[])
   float heat_g[] = {0.0, 0.0, 0.5, 1.0, 1.0};
   float heat_b[] = {0.0, 0.0, 0.0, 0.3, 1.0};
   float xmin,xmax,ymin,ymax,zmin,zmax=1.0;
-  int i,j,k,flag=0,isel=0,sn;
+  int i,j,k,flag=0,sn;
   int redraw=1,mode=0,posn=0,click=0,graves=0,grid=0;
   float dt,zzmax,s1,s2,z,za,sigma,zs,zm;
   int ix=0,iy=0,isub=0;
@@ -91,7 +91,6 @@ int main(int argc,char *argv[])
   sprintf(tlefile,"%s/bulk.tle",env);  
 
   // Set selection
-  isel=0;
   sel.n=0;
   sel.w=100.0;
   sel.sigma=5.0;
@@ -385,10 +384,9 @@ int main(int argc,char *argv[])
     // Select start
     if (c=='s') {
       if (sel.n < NMAX) {
-        sel.x[isel]=x;
-        sel.y[isel]=y;
-        isel++;
-        sel.n=isel;
+        sel.x[sel.n]=x;
+        sel.y[sel.n]=y;
+        sel.n++;
         redraw=1;
       } else {
         printf("Maximum number of %i selection point reached.\n", NMAX);
@@ -462,8 +460,7 @@ int main(int argc,char *argv[])
     // Undo
     if (c=='u') {
       if (sel.n > 0) {
-        isel--;
-        sel.n=isel;
+        sel.n--;
         redraw=1;
       }
     }
@@ -704,7 +701,6 @@ int main(int argc,char *argv[])
       xmax=(float) s.nsub;
       ymin=0.0;
       ymax=(float) s.nchan;
-      isel=0;
       sel.n=0;
       redraw=1;
       continue;


### PR DESCRIPTION
Hi Cees,

i propose you a little PR to fix a little overflow/underflow issue in rfplot's selection buffer.

If you delete (`u`) more points than you selected (`s`) you delete non-existent points. This is not dramatic. But if after that you create new selection points these new points will be created at negative array indexes, which causes a buffer underrun. You can easily reproduce that by pressing a few dozen times on `u` and then `s` which has good chances to lead to a crash.

This PR prevents deleting more points than have been created, and also creating more points than the statically allocated selection buffer.

In a separate commit i also remove the isel variable as it is duplicated with sel.n. This is pure refactory but makes the code a little easier and cleaner. If you prefer i can drop this second commit from my PR.

Cheers

Martin Herren - HB9FXX