### PR TITLE
New API to load sites from sites.txt / Add ST_SITES_TXT environment variable

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -16,8 +16,8 @@ bindir = $(exec_prefix)/bin
 all:
 	make rfedit rfplot rffft rfpng rffit rffind
 
-rffit: rffit.o sgdp4.o satutl.o deep.o ferror.o dsmin.o simplex.o versafit.o
-	gfortran -o rffit rffit.o sgdp4.o satutl.o deep.o ferror.o dsmin.o simplex.o versafit.o $(LFLAGS)
+rffit: rffit.o sgdp4.o satutl.o deep.o ferror.o dsmin.o simplex.o versafit.o rfsites.o
+	gfortran -o rffit rffit.o sgdp4.o satutl.o deep.o ferror.o dsmin.o simplex.o versafit.o rfsites.o $(LFLAGS)
 
 rfpng: rfpng.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o
 	gfortran -o rfpng rfpng.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o $(LFLAGS)

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -30,8 +30,8 @@ bindir = $(exec_prefix)/bin
 all:
 	make rfedit rfplot rffft rfpng rffit rffind
 
-rffit: rffit.o sgdp4.o satutl.o deep.o ferror.o dsmin.o simplex.o versafit.o
-	$(CC) -o rffit rffit.o sgdp4.o satutl.o deep.o ferror.o dsmin.o simplex.o versafit.o $(LFLAGS)
+rffit: rffit.o sgdp4.o satutl.o deep.o ferror.o dsmin.o simplex.o versafit.o rfsites.o
+	$(CC) -o rffit rffit.o sgdp4.o satutl.o deep.o ferror.o dsmin.o simplex.o versafit.o rfsites.o $(LFLAGS)
 
 rfpng: rfpng.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o
 	$(CC) -o rfpng rfpng.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o $(LFLAGS)

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ Install
 Configure
 ---------
 * You will need to set the following environment variables in your login file to run **strf**.
-	* `ST_DATADIR` path to **strf** directory (e.g. `$HOME/software/strf`)
+	* `ST_DATADIR` path to **strf** directory (e.g. `$HOME/software/strf`, default: './')
 	* `ST_TLEDIR` path to TLE directory (e.g. `$HOME/tle`)
 	* `ST_COSPAR` COSPAR site number (add to site location to `$ST_DATADIR/data/sites.txt`)
 	* `ST_LOGIN` space-track.org login info (of the form `ST_LOGIN="identity=username&password=password"`)
+    * `ST_SITES_TXT` path to sites.txt (optional, default: `$ST_DATADIR/data/sites.txt`)
 * Run `tleupdate` to download latest TLEs.
 * You should install NTP support on the system and configure time/date to automatically
   synchronize to time servers.

--- a/makefile
+++ b/makefile
@@ -16,8 +16,8 @@ bindir = $(exec_prefix)/bin
 all:
 	make rfedit rfplot rffft rfpng rffit rffind rfdop
 
-rffit: rffit.o sgdp4.o satutl.o deep.o ferror.o dsmin.o simplex.o versafit.o
-	gfortran -o rffit rffit.o sgdp4.o satutl.o deep.o ferror.o dsmin.o simplex.o versafit.o $(LFLAGS)
+rffit: rffit.o sgdp4.o satutl.o deep.o ferror.o dsmin.o simplex.o versafit.o rfsites.o
+	gfortran -o rffit rffit.o sgdp4.o satutl.o deep.o ferror.o dsmin.o simplex.o versafit.o rfsites.o $(LFLAGS)
 
 rfpng: rfpng.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o
 	gfortran -o rfpng rfpng.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o $(LFLAGS)

--- a/rffit.c
+++ b/rffit.c
@@ -555,14 +555,16 @@ int main(int argc,char *argv[])
 	
 	// Loop over sites for plotting model
 	for (j=0;j<nsite;j++) {
-	  s0=get_site(site_number[j]);
-	  s1=get_site(d.p[0].rsite_id);
+	  s0 = get_site(site_number[j]);
+	  if (d.p[0].rsite_id != 0) {
+	    s1 = get_site(d.p[0].rsite_id);
+      }
 	  color=j+2;
 
 	  for (i=0;i<NMAX;i++) {
 	    mjd=xmin+d.mjd0+(xmax-xmin)*(float) i/(float) (NMAX-1);
 	    t=(float) (mjd-d.mjd0);
-	    if (d.p[0].rsite_id!=0) {
+	    if (d.p[0].rsite_id != 0) {
 	      velocity(orb,mjd,s1,&v1,&azi,&alt);
 	      velocity(orb,mjd,s0,&v,&azi,&alt);
 	      f=(float) ((1.0-v/C)*(1.0-v1/C)*d.ffit-d.f0);

--- a/rfsites.c
+++ b/rfsites.c
@@ -1,0 +1,60 @@
+#include "rfsites.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define LIM 80
+
+// Get observing site
+site_t get_site(int site_id) {
+  int i=0,status;
+  char line[LIM];
+  FILE *file;
+  int id;
+  double lat,lng;
+  float alt;
+  char abbrev[3],observer[64];
+  site_t s;
+  char *env,filename[LIM];
+
+  env=getenv("ST_DATADIR");
+  if(env==NULL||strlen(env)==0)
+    env=".";
+  sprintf(filename,"%s/data/sites.txt",env);
+
+  file=fopen(filename,"r");
+  if (file==NULL) {
+    printf("File with site information not found!\n");
+    exit(0);
+  }
+  while (fgets(line,LIM,file)!=NULL) {
+    // Skip
+    if (strstr(line,"#")!=NULL)
+      continue;
+
+    // Strip newline
+    line[strlen(line)-1]='\0';
+
+    // Read data
+    status=sscanf(line,"%4d %2s %lf %lf %f",
+	   &id,abbrev,&lat,&lng,&alt);
+    strcpy(observer,line+38);
+
+    // Change to km
+    alt/=1000.0;
+    
+    // Copy site
+    if (id==site_id) {
+      s.lat=lat;
+      s.lng=lng;
+      s.alt=alt;
+      s.id=id;
+      strcpy(s.observer,observer);
+    }
+
+  }
+  fclose(file);
+
+  return s;
+}

--- a/rfsites.c
+++ b/rfsites.c
@@ -16,12 +16,19 @@ site_t get_site(int site_id) {
   float alt;
   char abbrev[3],observer[64];
   site_t s;
-  char *env,filename[LIM];
+  char *env_datadir,*env_sites_txt,filename[LIM];
 
-  env=getenv("ST_DATADIR");
-  if(env==NULL||strlen(env)==0)
-    env=".";
-  sprintf(filename,"%s/data/sites.txt",env);
+  env_datadir = getenv("ST_DATADIR");
+  if (env_datadir == NULL || strlen(env_datadir) == 0) {
+    env_datadir = ".";
+  }
+
+  env_sites_txt = getenv("ST_SITES_TXT");
+  if (env_sites_txt == NULL || strlen(env_sites_txt) == 0) {
+    sprintf(filename, "%s/data/sites.txt", env_datadir);
+  } else {
+    sprintf(filename, "%s", env_datadir);
+  }
 
   file=fopen(filename,"r");
   if (file==NULL) {

--- a/rfsites.c
+++ b/rfsites.c
@@ -9,6 +9,7 @@
 // Get observing site
 site_t get_site(int site_id) {
   int i=0,status;
+  int count = 0;
   char line[LIM];
   FILE *file;
   int id;
@@ -27,12 +28,12 @@ site_t get_site(int site_id) {
   if (env_sites_txt == NULL || strlen(env_sites_txt) == 0) {
     sprintf(filename, "%s/data/sites.txt", env_datadir);
   } else {
-    sprintf(filename, "%s", env_datadir);
+    sprintf(filename, "%s", env_sites_txt);
   }
 
   file=fopen(filename,"r");
   if (file==NULL) {
-    printf("File with site information not found!\n");
+    printf("File with site information not count!\n");
     exit(0);
   }
   while (fgets(line,LIM,file)!=NULL) {
@@ -53,6 +54,7 @@ site_t get_site(int site_id) {
     
     // Copy site
     if (id==site_id) {
+      count += 1;
       s.lat=lat;
       s.lng=lng;
       s.alt=alt;
@@ -62,6 +64,13 @@ site_t get_site(int site_id) {
 
   }
   fclose(file);
+
+  if (count == 0) {
+    printf("Error: Site %d was not found in sites.txt!", site_id);
+    exit(-1);
+  } else if (count > 1) {
+    printf("Site %d was found multiple times in sites.txt, use last occurence.", site_id);
+  }
 
   return s;
 }

--- a/rfsites.h
+++ b/rfsites.h
@@ -1,0 +1,21 @@
+#ifndef _RFSITES_H
+#define _RFSITES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct site {
+  int id;
+  double lat,lng;
+  float alt;
+  char observer[64];
+} site_t;
+
+site_t get_site(int site_id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _RFSITES_H */


### PR DESCRIPTION
This PR is aimed at improving sites.txt handling.

The first commit is refactoring existing code only, with the goal of providing
a common API for loading sites from sites.txt, usable by multiple tools (currently rffit only).

The second commit adds the optional ST_SITES_TXT environment variable. This was needed in addition to the existing ST_DATADIR, because the latter is used by sattools for other things too. ST_SITES_TXT is especially useful when using a sites.txt maintained by the satnogs-tabulation-helper (--> the sites.txt using COSPAR ids and SatNOGS Station IDs can co-exist separately now).

The third commit is a bug fix (rffit: only call get_site(rsite_id) if rsite_id is non-zero).

The forth commit adds error/warning messages if site is missing/duplicate from sites.txt. Previously a missing site / wrongly configured sites.txt was a common source of frustration for me. Typical symptom previously: invalid station name & frequency prediction all over the place. Now: graceful error handling with messages.