### PR TITLE
rffit: If ST_COSPAR is not set, use first site from datafile

### DIFF
--- a/rffit.c
+++ b/rffit.c
@@ -263,7 +263,7 @@ int main(int argc,char *argv[])
   int i,j,flag,redraw=1,plot_curve=1,plot_type=1,residuals=0,elset=0;
   int imode,year,style,color;
   char xlabel[64],ylabel[32],text[64],freqlist[128];
-  int site_id=4171;
+  int site_id=0;
   float xmin,xmax,ymin,ymax;
   float xminsel,xmaxsel,yminsel,ymaxsel;
   float x0=0.0,y0=0.0,x=0.0,y=0.0;
@@ -283,11 +283,9 @@ int main(int argc,char *argv[])
   char *env;
 
   // Get site
-  env=getenv("ST_COSPAR");
-  if (env!=NULL) {
-    site_id=atoi(env);
-  } else {
-    printf("ST_COSPAR environment variable not found.\n");
+  env = getenv("ST_COSPAR");
+  if (env != NULL) {
+    site_id = atoi(env);
   }
 
   // Get frequency list
@@ -325,7 +323,7 @@ int main(int argc,char *argv[])
       break;
       
     case 's':
-      site_id=atoi(optarg);
+      site_id = atoi(optarg);
       break;
 
     case 'g':
@@ -352,11 +350,11 @@ int main(int argc,char *argv[])
   for (i=0;i<d.n;i++) {
     // Check if site is assigned
     for (j=0,flag=0;j<nsite;j++) 
-      if (site_number[j]==d.p[i].site_id)
-	flag=1;
+      if (site_number[j] == d.p[i].site_id)
+	    flag = 1;
     
     // Not assigned
-    if (flag==0) {
+    if (flag == 0) {
       site_number[nsite]=d.p[i].site_id;
       nsite++;
     }
@@ -365,6 +363,17 @@ int main(int argc,char *argv[])
       return 0;
     }
   }
+
+  if (site_id == 0) {
+      // No default site selected.
+      // Select first site from datafile
+      if (nsite > 0) {
+        site_id = site_number[0];
+      } else {
+        printf("No default site given and no site in datafile found, abort.");
+      }
+  }
+  printf("%d\n", site_id);
 
   // Set default observing site
   site = get_site(site_id);

--- a/rfsites.c
+++ b/rfsites.c
@@ -66,10 +66,10 @@ site_t get_site(int site_id) {
   fclose(file);
 
   if (count == 0) {
-    printf("Error: Site %d was not found in sites.txt!", site_id);
+    printf("Error: Site %d was not found in %s!\n", site_id, filename);
     exit(-1);
   } else if (count > 1) {
-    printf("Site %d was found multiple times in sites.txt, use last occurence.", site_id);
+    printf("Site %d was found multiple times in %s, use last occurence.\n", site_id, filename);
   }
 
   return s;


### PR DESCRIPTION
If rffit is called without `ST_COSPAR` being set, it selects the first site from the data now as the "main site" for the polar plot on the right side of the screen. This makes it easier to plot data from multiple stations as no manual setup of the ST_COSPAR variable is required anymore.

Additionally bug fix: if no `ST_COSPAR` and no site-id is set as command-line argument either, rffit terminates with an error message. Previously this resulted in a segmentation fault or undefined behavior.