### PR TITLE
[Sites] Allow site IDs with more than 4 digits

### DIFF
--- a/rfsites.c
+++ b/rfsites.c
@@ -45,13 +45,13 @@ site_t get_site(int site_id) {
     line[strlen(line)-1]='\0';
 
     // Read data
-    status=sscanf(line,"%4d %2s %lf %lf %f",
+    status=sscanf(line,"%d %2s %lf %lf %f",
 	   &id,abbrev,&lat,&lng,&alt);
     strcpy(observer,line+38);
 
     // Change to km
     alt/=1000.0;
-    
+
     // Copy site
     if (id==site_id) {
       count += 1;

--- a/rftrace.c
+++ b/rftrace.c
@@ -145,7 +145,7 @@ struct site get_site(int site_id)
     line[strlen(line)-1]='\0';
 
     // Read data
-    status=sscanf(line,"%4d %2s %lf %lf %f",
+    status=sscanf(line,"%d %2s %lf %lf %f",
 	   &id,abbrev,&lat,&lng,&alt);
     strcpy(observer,line+38);
 


### PR DESCRIPTION
This PR allows to use more digits on site ids. Even if all the official ids use only 4 digit, it makes it easier to use unofficial ones in the 5 digit ranges to avoid conflicts when exchanging files.

We could even do our own unofficial list of ids for the satnogs community without risking conflicting with future official ones.