### PR TITLE
rffft wav support

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -5,7 +5,7 @@ jobs:
   GitHub-Actions:
     runs-on: ubuntu-latest
     steps:
-      - run: sudo apt install --no-install-recommends make gcc pgplot5 gfortran libpng-dev libx11-dev libgsl-dev libfftw3-dev libcmocka-dev libcmocka0
+      - run: sudo apt install --no-install-recommends make gcc pgplot5 gfortran libpng-dev libx11-dev libgsl-dev libfftw3-dev libsox-dev libcmocka-dev libcmocka0
       - name: Check out repository code
         uses: actions/checkout@v3
       - run: cd ${{ github.workspace }}

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -35,7 +35,7 @@ rfplot: rfplot.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o rftl
 	gfortran -o rfplot rfplot.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o rftles.o $(LFLAGS)
 
 rffft: rffft.o rffft_internal.o rftime.o
-	$(CC) -o rffft rffft.o rffft_internal.o rftime.o -lfftw3f -lm
+	$(CC) -o rffft rffft.o rffft_internal.o rftime.o -lfftw3f -lm -lsox
 
 tests/tests: tests/tests.o tests/tests_rffft_internal.o tests/tests_rftles.o rffft_internal.o rftles.o satutl.o ferror.o
 	$(CC) -Wall -o $@ $^ -lcmocka -lm

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -49,7 +49,7 @@ rfplot: rfplot.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o vers
 	$(CC) -o rfplot rfplot.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o versafit.o dsmin.o simplex.o rftles.o $(LFLAGS)
 
 rffft: rffft.o rffft_internal.o rftime.o
-	$(CC) -o rffft rffft.o rffft_internal.o rftime.o -lfftw3f -lm $(LFLAGS)
+	$(CC) -o rffft rffft.o rffft_internal.o rftime.o -lfftw3f -lm -lsox $(LFLAGS)
 
 tests/tests: tests/tests.o tests/tests_rffft_internal.o tests/tests_rftles.o rffft_internal.o rftles.o satutl.o ferror.o
 	$(CC) -Wall -o $@ $^ -lcmocka -lm

--- a/README.md
+++ b/README.md
@@ -92,6 +92,6 @@ It is also possible to read WAV files. This is compatible with any WAV file, 16 
 
     ./rffft -i recording.wav -f 97400000 -s 48000 -F wav -T "YYYY-MM-DDTHH:MM:SS"
 
-For WAV files exported from SatDump the `-P` options will automatically extract the correct parameters from the filename.
+For WAV files exported from SatDump and SDR Console the `-P` options will automatically extract the correct parameters from the filename.
 
 The output spectrograms can be viewed and analysed using `rfplot`.

--- a/README.md
+++ b/README.md
@@ -92,4 +92,6 @@ It is also possible to read WAV files. This is compatible with any WAV file, 16 
 
     ./rffft -i recording.wav -f 97400000 -s 48000 -F wav -T "YYYY-MM-DDTHH:MM:SS"
 
+For WAV files exported from SatDump the `-P` options will automatically extract the correct parameters from the filename.
+
 The output spectrograms can be viewed and analysed using `rfplot`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install
 ------
 
 * For Ubuntu systems or similar.
-  * Install dependencies: `sudo apt install git make gcc pgplot5 gfortran libpng-dev libx11-dev libgsl-dev libfftw3-dev dos2unix`
+  * Install dependencies: `sudo apt install git make gcc pgplot5 gfortran libpng-dev libx11-dev libgsl-dev libfftw3-dev libsox-dev dos2unix`
     * On recent systems (starting with Debian 13 Trixie and Ubuntu 24.10 Oracular), you'll need to install `sudo apt install pgplot5-dev`
   * Clone repository: `git clone https://github.com/cbassa/strf.git`
   * Compile: `cd strf; make`
@@ -85,5 +85,11 @@ With I/Q recordings obtained from Gqrx:
 Alternatively, with I/Q recordings from GQRX and SatDump, the `-P` option can be used to automatically extract the timestamp, format, frequency and samplerate from the filename:
 
     ./rffft -P -i gqrx_YYYYMMDD_HHMMSS_97400000_2000000_fc.raw
+
+Reading WAV files:
+
+It is also possible to read WAV files. This is compatible with any WAV file, 16 bit int or 32 bit float for example as well as RF64 (WAV64) files.
+
+    ./rffft -i recording.wav -f 97400000 -s 48000 -F wav -T "YYYY-MM-DDTHH:MM:SS"
 
 The output spectrograms can be viewed and analysed using `rfplot`.

--- a/makefile
+++ b/makefile
@@ -38,7 +38,7 @@ rfplot: rfplot.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o vers
 	gfortran -o rfplot rfplot.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o versafit.o dsmin.o simplex.o rftles.o $(LFLAGS)
 
 rffft: rffft.o rffft_internal.o rftime.o
-	$(CC) -o rffft rffft.o rffft_internal.o rftime.o -lfftw3f -lm
+	$(CC) -o rffft rffft.o rffft_internal.o rftime.o -lfftw3f -lm -lsox
 
 tests/tests: tests/tests.o tests/tests_rffft_internal.o tests/tests_rftles.o rffft_internal.o rftles.o satutl.o ferror.o
 	$(CC) -Wall -o $@ $^ -lcmocka -lm

--- a/rffft.c
+++ b/rffft.c
@@ -175,7 +175,7 @@ int main(int argc,char *argv[])
     wav_reader = sox_open_read(infname, NULL, NULL, NULL);
 
     if (wav_reader == NULL) {
-      fprintf(stderr, "Error opening file %s", infile);
+      fprintf(stderr, "Error opening file %s", infname);
       exit(-1);
     }
 

--- a/rffft_internal.c
+++ b/rffft_internal.c
@@ -20,12 +20,14 @@
 // - GQRX:
 //   - gqrx_20230806_151838_428000000_200000_fc.raw
 //   format always float32
+// - SDR Console:
+//   - 07-Aug-2023 181711.798 401.774MHz.wav
 int rffft_params_from_filename(char * filename, double * samplerate, double * frequency, char * format, char * starttime) {
   // Temp vars to hold parsed values
   int p_year, p_month, p_day, p_hours, p_minutes, p_seconds, p_fractal_seconds;
   int p_dummy_int;
   double p_samplerate, p_frequency;
-  char p_format[16];
+  char p_month_string[16], p_format[16];
   char p_dummy_string[128];
   int parsed_tokens;
 
@@ -162,6 +164,60 @@ int rffft_params_from_filename(char * filename, double * samplerate, double * fr
     *format = 'f';
 
     snprintf(starttime, 32, "%04d-%02d-%02dT%02d:%02d:%02d", p_year, p_month, p_day, p_hours, p_minutes, p_seconds);
+
+    return 0;
+  }
+
+  // SDR Console
+  parsed_tokens = sscanf(
+    base_filename,
+    "%02d-%3s-%04d %02d%02d%02d.%03d %lfMHz.wav",
+    &p_day,
+    p_month_string,
+    &p_year,
+    &p_hours,
+    &p_minutes,
+    &p_seconds,
+    &p_fractal_seconds,
+    &p_frequency);
+
+  if (parsed_tokens == 8) {
+    *samplerate = 0; // Will be set when opening the wav
+    *frequency = p_frequency * 1e6;
+    *format = 'w';
+
+    int month;
+
+    if ((strlen(p_month_string) == 3) && (strncmp("Jan", p_month_string, 3) == 0)) {
+      month = 1;
+    } else if ((strlen(p_month_string) == 3) && (strncmp("Feb", p_month_string, 3) == 0)) {
+      month = 2;
+    } else if ((strlen(p_month_string) == 3) && (strncmp("Mar", p_month_string, 3) == 0)) {
+      month = 3;
+    } else if ((strlen(p_month_string) == 3) && (strncmp("Apr", p_month_string, 3) == 0)) {
+      month = 4;
+    } else if ((strlen(p_month_string) == 3) && (strncmp("May", p_month_string, 3) == 0)) {
+      month = 5;
+    } else if ((strlen(p_month_string) == 3) && (strncmp("Jun", p_month_string, 3) == 0)) {
+      month = 6;
+    } else if ((strlen(p_month_string) == 3) && (strncmp("Jul", p_month_string, 3) == 0)) {
+      month = 7;
+    } else if ((strlen(p_month_string) == 3) && (strncmp("Aug", p_month_string, 3) == 0)) {
+      month = 8;
+    } else if ((strlen(p_month_string) == 3) && (strncmp("Sep", p_month_string, 3) == 0)) {
+      month = 9;
+    } else if ((strlen(p_month_string) == 3) && (strncmp("Oct", p_month_string, 3) == 0)) {
+      month = 10;
+    } else if ((strlen(p_month_string) == 3) && (strncmp("Nov", p_month_string, 3) == 0)) {
+      month = 11;
+    } else if ((strlen(p_month_string) == 3) && (strncmp("Dec", p_month_string, 3) == 0)) {
+      month = 12;
+    } else {
+      printf("Unparsable month in SDR Console format %s\n", p_format);
+      return -1;
+    }
+
+    snprintf(starttime, 32, "%04d-%02d-%02dT%02d:%02d:%02d.%03d", p_year, month, p_day, p_hours, p_minutes, p_seconds, p_fractal_seconds);
 
     return 0;
   }

--- a/rffft_internal.c
+++ b/rffft_internal.c
@@ -11,8 +11,9 @@
 //   - 2023-08-05_08-02-00_16000000SPS_2274000000Hz.s8
 //   - 2023-08-05_18-02-45-534_16000000SPS_2284000000Hz.s16
 //   - 2023-08-05_18-02-45-1691258565.534000_16000000SPS_2284000000Hz.f32
+//   - 2023-08-07_16-36-47-1691426207.749000_2400000SPS_100000000Hz.wav
 //   s8: char, s16 short int, f32 float.
-//   SatDump also supports .wav and compressed versions of s8/s16/f32 with .ziq
+//   SatDump also supports a compressed versions of s8/s16/f32 with .ziq
 //   extension. Those are not yet supported
 //   timestamp can have an added milliseconds field, configurable. This feature
 //   was broken during some time so files with this convention still exists.
@@ -56,6 +57,8 @@ int rffft_params_from_filename(char * filename, double * samplerate, double * fr
       *format = 'i';
     } else if ((strlen(p_format) == 3) && (strncmp("f32", p_format, 3) == 0)) {
       *format = 'f';
+    } else if ((strlen(p_format) == 3) && (strncmp("wav", p_format, 3) == 0)) {
+      *format = 'w';
     } else {
       printf("Unsupported SatDump format %s\n", p_format);
       return -1;
@@ -91,6 +94,8 @@ int rffft_params_from_filename(char * filename, double * samplerate, double * fr
       *format = 'i';
     } else if ((strlen(p_format) == 3) && (strncmp("f32", p_format, 3) == 0)) {
       *format = 'f';
+    } else if ((strlen(p_format) == 3) && (strncmp("wav", p_format, 3) == 0)) {
+      *format = 'w';
     } else {
       printf("Unsupported SatDump format %s\n", p_format);
       return -1;
@@ -125,6 +130,8 @@ int rffft_params_from_filename(char * filename, double * samplerate, double * fr
       *format = 'i';
     } else if ((strlen(p_format) == 3) && (strncmp("f32", p_format, 3) == 0)) {
       *format = 'f';
+    } else if ((strlen(p_format) == 3) && (strncmp("wav", p_format, 3) == 0)) {
+      *format = 'w';
     } else {
       printf("Unsupported SatDump format %s\n", p_format);
       return -1;

--- a/rffft_internal.h
+++ b/rffft_internal.h
@@ -12,7 +12,7 @@ extern "C" {
 // output:
 // samplerate: parsed samplerate
 // frequency: parsed frequency
-// format: parsed sample format: char: 'c', int: 'i', float: 'f'
+// format: parsed sample format: char: 'c', int: 'i', float: 'f', wav: 'w'
 // starttime: parsed start time string formatted YYYY-MM-DDTHH:MM:SS.sss
 int rffft_params_from_filename(char * filename, double * samplerate, double * frequency, char * format, char * starttime);
 

--- a/tests/tests_rffft_internal.c
+++ b/tests/tests_rffft_internal.c
@@ -73,11 +73,31 @@ void rffft_internal_parse_gqrx_filenames(void **state) {
   assert_int_equal(-1, rffft_params_from_filename("gqrx_2023-08-06_15:18:38_428000000_200000_fc.raw", &samplerate, &frequency, &format, starttime));
 }
 
+// Test SDR Console filenames
+void rffft_internal_parse_sdrconsole_filenames(void **state) {
+  double samplerate = 0;
+  double frequency = 0;
+  char format = '\0';
+  char starttime[] = "YYYY-mm-ddTHH:MM:SS.sss";
+  char ref_format = '\0';
+
+  ref_format = 'w';
+  assert_int_equal(0, rffft_params_from_filename("07-Aug-2023 181711.798 401.774MHz.wav", &samplerate, &frequency, &format, starttime));
+  // assert_double_equal has been introduced in cmocka 1.1.6 not available on most distribs yet
+  assert_float_equal(0, samplerate, 1e-12);
+  assert_float_equal(401.774e6, frequency, 1e-12);
+  assert_memory_equal(&ref_format, &format, 1);
+  assert_string_equal("2023-08-07T18:17:11.798", starttime);
+
+  assert_int_equal(-1, rffft_params_from_filename("07-Yol-2023 181711.798 401.774MHz.wav", &samplerate, &frequency, &format, starttime));
+}
+
 // Entry point to run all tests
 int run_rffft_internal_tests() {
   const struct CMUnitTest tests[] = {
     cmocka_unit_test(rffft_internal_parse_satdump_filenames),
     cmocka_unit_test(rffft_internal_parse_gqrx_filenames),
+    cmocka_unit_test(rffft_internal_parse_sdrconsole_filenames),
   };
 
   return cmocka_run_group_tests_name("rffft internal", tests, NULL, NULL);

--- a/tests/tests_rffft_internal.c
+++ b/tests/tests_rffft_internal.c
@@ -43,6 +43,14 @@ void rffft_internal_parse_satdump_filenames(void **state) {
   assert_memory_equal(&ref_format, &format, 1);
   assert_string_equal("2023-08-05T18:02:45.534", starttime);
 
+  // wav file with milliseconds
+  ref_format = 'w';
+  assert_int_equal(0, rffft_params_from_filename("2023-08-07_16-36-47-749_2400000SPS_100000000Hz.wav", &samplerate, &frequency, &format, starttime));
+  assert_float_equal(2.4e6, samplerate, 1e-12);
+  assert_float_equal(100e6, frequency, 1e-12);
+  assert_memory_equal(&ref_format, &format, 1);
+  assert_string_equal("2023-08-07T16:36:47.749", starttime);
+
   assert_int_equal(-1, rffft_params_from_filename("2023-08-05-19:59:30_16000000SPS_402000000Hz.f32", &samplerate, &frequency, &format, starttime));
 }
 


### PR DESCRIPTION
This PR adds native WAV file support to rffft. It works as well with int16, float32 and other WAV files as well as RF64 (WAV64).
As it is based on PR #52 it also adds automatic options extraction through the `-P` parameter from the filename of WAV files exported from SatDump and SDR Console.

This PR is based on #52 (and thus also #48) so should not be merged before they are merged.