### PR TITLE
Update tleupdate

### DIFF
--- a/tleupdate
+++ b/tleupdate
@@ -46,6 +46,6 @@ dos2unix kepler.tle
 sed -i -e "s/^1     /1 0000/g" -e "s/^2     /2 0000/g" -e "s/^1    /1 000/g" -e "s/^2    /2 000/g" -e "s/^1   /1 00/g" -e "s/^2   /2 00/g" -e "s/^1  /1 0/g" -e "s/^2  /2 0/g" kepler.tle
 
 # Create TLE bulk file
-cat classfd.tle catalog.tle kepler.tle >bulk.tle
+cat classfd.tle kepler.tle catalog.tle >bulk.tle
 #cat classfd.tle catalog.tle >bulk.tle
 cat bulk.tle | grep -e "^1 "  | awk '{if ($2<80000 || $2>99000) printf("%05d %s\n",$2,$3)}'  | sort | uniq >$ST_DATADIR/data/desig.txt


### PR DESCRIPTION
At the moment all TLE objects in bulk.tle that are appended after catalog.tle are disregarded due to the fact that the Txxxx objects cause a disregard/failure of further processing.

As a workaround with the new Txxxx objects in catalog.tle make sure catalog.tle is the last file that is appended to bulk.tle.