### PR TITLE
rfplot: Add support for start and end dates

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -37,10 +37,19 @@ rfplot: rfplot.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o rftl
 rffft: rffft.o rffft_internal.o rftime.o
 	$(CC) -o rffft rffft.o rffft_internal.o rftime.o -lfftw3f -lm -lsox
 
-tests/tests: tests/tests.o tests/tests_rffft_internal.o tests/tests_rftles.o rffft_internal.o rftles.o satutl.o ferror.o
+tests/tests: tests/tests.o tests/tests_rffft_internal.o tests/tests_rfio.o tests/tests_rftles.o rffft_internal.o rfio.o rftime.o rftles.o satutl.o ferror.o zscale.o
 	$(CC) -Wall -o $@ $^ -lcmocka -lm
 
-tests: tests/tests
+tests/random:
+	dd if=/dev/random of=tests/random bs=12288000 count=4
+
+tests/bins: rffft tests/random
+	mkdir -p tests/bin/
+	./rffft -i tests/random -p tests/bin/ -o t10_n120_32 -f 2250000000 -s 1024 -T 2016-09-28T00:20:00 -t 10 -n 120
+	./rffft -i tests/random -p tests/bin/ -o t15_n90_8 -f 2250000000 -s 1024 -T 2016-09-28T00:20:00 -t 15 -n 90 -b
+	touch tests/bins
+
+tests: tests/tests tests/bins
 	./tests/tests
 
 .PHONY: clean install uninstall tests

--- a/Makefile.osx
+++ b/Makefile.osx
@@ -51,10 +51,19 @@ rfplot: rfplot.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o vers
 rffft: rffft.o rffft_internal.o rftime.o
 	$(CC) -o rffft rffft.o rffft_internal.o rftime.o -lfftw3f -lm -lsox $(LFLAGS)
 
-tests/tests: tests/tests.o tests/tests_rffft_internal.o tests/tests_rftles.o rffft_internal.o rftles.o satutl.o ferror.o
+tests/tests: tests/tests.o tests/tests_rffft_internal.o tests/tests_rfio.o tests/tests_rftles.o rffft_internal.o rfio.o rftime.o rftles.o satutl.o ferror.o zscale.o
 	$(CC) -Wall -o $@ $^ -lcmocka -lm
 
-tests: tests/tests
+tests/random:
+	dd if=/dev/random of=tests/random bs=12288000 count=4
+
+tests/bins: rffft tests/random
+	mkdir -p tests/bin/
+	./rffft -i tests/random -p tests/bin/ -o t10_n120_32 -f 2250000000 -s 1024 -T 2016-09-28T00:20:00 -t 10 -n 120
+	./rffft -i tests/random -p tests/bin/ -o t15_n90_8 -f 2250000000 -s 1024 -T 2016-09-28T00:20:00 -t 15 -n 90 -b
+	touch tests/bins
+
+tests: tests/tests tests/bins
 	./tests/tests
 
 .PHONY: clean install uninstall tests

--- a/makefile
+++ b/makefile
@@ -40,10 +40,19 @@ rfplot: rfplot.o rftime.o rfio.o rftrace.o sgdp4.o satutl.o deep.o ferror.o vers
 rffft: rffft.o rffft_internal.o rftime.o
 	$(CC) -o rffft rffft.o rffft_internal.o rftime.o -lfftw3f -lm -lsox
 
-tests/tests: tests/tests.o tests/tests_rffft_internal.o tests/tests_rftles.o rffft_internal.o rftles.o satutl.o ferror.o
+tests/tests: tests/tests.o tests/tests_rffft_internal.o tests/tests_rfio.o tests/tests_rftles.o rffft_internal.o rfio.o rftime.o rftles.o satutl.o ferror.o zscale.o
 	$(CC) -Wall -o $@ $^ -lcmocka -lm
 
-tests: tests/tests
+tests/random:
+	dd if=/dev/random of=tests/random bs=12288000 count=4
+
+tests/bins: rffft tests/random
+	mkdir -p tests/bin/
+	./rffft -i tests/random -p tests/bin/ -o t10_n120_32 -f 2250000000 -s 1024 -T 2016-09-28T00:20:00 -t 10 -n 120
+	./rffft -i tests/random -p tests/bin/ -o t15_n90_8 -f 2250000000 -s 1024 -T 2016-09-28T00:20:00 -t 15 -n 90 -b
+	touch tests/bins
+
+tests: tests/tests tests/bins
 	./tests/tests
 
 .PHONY: clean install uninstall tests

--- a/rffit.c
+++ b/rffit.c
@@ -188,7 +188,7 @@ int identify_satellite_from_doppler(tle_array_t *tle_array, double rmsmax)
     }
     if (rms<rmsmax) {
       if (tle->name) {
-        printf("%05d: %.3f kHz %.6f MHz | %s\n", orb.satno, tle->name, rms, d.ffit/1000.0, tle->name);
+        printf("%05d: %.3f kHz %.6f MHz | %s\n", orb.satno, rms, d.ffit/1000.0, tle->name);
       } else {
         printf("%05d: %.3f kHz %.6f MHz\n", orb.satno, rms, d.ffit/1000.0);
       }

--- a/rfio.c
+++ b/rfio.c
@@ -8,7 +8,7 @@
 
 struct spectrogram read_spectrogram(char *prefix,int isub,int nsub,double f0,double df0,int nbin,double foff)
 {
-  int i,j,k,l,flag=0,status,msub,ibin,nadd,nbits=-32;
+  int i,j,k,l,status,msub,ibin,nadd,nbits=-32;
   char filename[128],header[256],nfd[32];
   FILE *file;
   struct spectrogram s;
@@ -18,7 +18,6 @@ struct spectrogram read_spectrogram(char *prefix,int isub,int nsub,double f0,dou
   double freq,samp_rate;
   float length;
   int nchan,dummy;
-  float s1,s2;
 
   // Open first file to get number of channels
   sprintf(filename,"%s_%06d.bin",prefix,isub);

--- a/rfio.h
+++ b/rfio.h
@@ -1,5 +1,8 @@
 #ifndef RFIO_H
 #define RFIO_H
+
+#include <time.h>
+
 struct spectrogram {
   int nsub,nchan,msub,isub;
   double *mjd;
@@ -9,7 +12,15 @@ struct spectrogram {
   float zmin,zmax;
   char nfd0[32];
 };
+
+int get_bin_range(char *prefix, int *first_bin, int *last_bin);
+int get_bin_from_time(char *prefix, int initial_bin, int previous_bin,
+                      int first_bin, int last_bin, time_t target,
+                      int *number_subints_per_file);
+int get_subs_from_datestrings(char *prefix, char *start, char *end,
+                              int *start_bin, int *num_integrations);
 struct spectrogram read_spectrogram(char *prefix,int isub,int nsub,double f0,double df0,int nbin,double foff);
 void write_spectrogram(struct spectrogram s,char *prefix);
 void free_spectrogram(struct spectrogram s);
-#endif
+
+#endif // RFIO_H

--- a/rfplot.c
+++ b/rfplot.c
@@ -82,6 +82,8 @@ int main(int argc,char *argv[])
   double foff=0.0,mjdgrid=0.0;
   int jj0,jj1;
   int show_names = 0;
+  char * start_time = NULL;
+  char * end_time = NULL;
 
   // Get site
   env=getenv("ST_COSPAR");
@@ -106,7 +108,7 @@ int main(int argc,char *argv[])
   
   // Read arguments
   if (argc>1) {
-    while ((arg=getopt(argc,argv,"p:f:w:s:l:b:z:hc:C:gm:o:S:W:F:n"))!=-1) {
+    while ((arg=getopt(argc,argv,"p:f:w:s:l:b:z:hc:C:gm:o:S:W:F:nT:E:"))!=-1) {
       switch (arg) {
 	
       case 'p':
@@ -180,6 +182,14 @@ int main(int argc,char *argv[])
         show_names = 1;
         break;
 
+        case 'T':
+          start_time = optarg;
+          break;
+
+        case 'E':
+          end_time = optarg;
+          break;
+
       default:
 	usage();
 	return 0;
@@ -188,6 +198,16 @@ int main(int argc,char *argv[])
   } else {
     usage();
     return 0;
+  }
+
+  if (start_time || end_time) {
+    status = get_subs_from_datestrings(path, start_time, end_time, &isub, &nsub);
+
+    if (status != 0) {
+      printf("Failed to read files or requested period out of bin range\n");
+
+      return -1;
+    }
   }
 
   // Read data
@@ -1043,6 +1063,10 @@ void usage(void)
   printf("-C <site>     Site ID\n");
   printf("-c <catalog>  TLE catalog\n");
   printf("-F <freqlist> List with frequencies [$ST_DATADIR/data/frequencies.txt]\n");
+  printf("-T <time>     Start time to plot, in the format YYYY-MM-DDTHH.mm.ss\n");
+  printf("              This setting overrides the -s setting\n");
+  printf("-E <time>     End time to plot, in the format YYYY-MM-DDTHH.mm.ss\n");
+  printf("              This setting overrides the -l setting\n");
   printf("-g            GRAVES data\n");
   printf("-n            Display satellite names\n");
   printf("-h            This help\n");

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,3 @@
+random
+bin/
+bins

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -1,4 +1,5 @@
 #include "tests_rffft_internal.h"
+#include "tests_rfio.h"
 #include "tests_rftles.h"
 
 #include <stdarg.h>
@@ -11,6 +12,7 @@ int main(void) {
   int failures = 0;
 
   failures += run_rffft_internal_tests();
+  failures += run_io_tests();
   failures += run_tle_tests();
 
   return failures;

--- a/tests/tests_rfio.c
+++ b/tests/tests_rfio.c
@@ -1,0 +1,368 @@
+#include "tests_rfio.h"
+
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <cmocka.h>
+
+#include "../rfio.h"
+
+// Test sets
+// There are 2 test sets consisting of 200 minutes of random 1024 S/s int16 IQ
+// samples,
+//
+// they where generated as follow
+// $ dd if=/dev/random of=random bs=12288000 count=4
+// $ ./rffft -i random -p tests/bin/ -o t10_n120_32 -f 2250000000 -s 1024 -T 2016-09-28T00:20:00 -t 10 -n 120
+// $ ./rffft -i random -p tests/bin/ -o t15_n90_8 -f 2250000000 -s 1024 -T 2016-09-28T00:20:00 -t 15 -n 90 -b
+//
+// Those 2 sets have different integration times, number of integrations per
+// file and sample format The first one has 20 minutes per file, the second 22
+// minutes and 30 seconds per file
+//
+// t10_n120_32 bin start times:
+//  0: 00:20:00
+//  1: 00:40:00
+//  2: 01:00:00
+//  3: 01:20:00
+//  4: 01:40:00
+//  5: 02:00:00
+//  6: 02:20:00
+//  7: 02:40:00
+//  8: 03:00:00
+//  9: 03:20:00
+// 10: 03:40:00
+//
+// t15_n90_8 bin start times:
+//  0: 00:20:00
+//  1: 00:42:30
+//  2: 01:05:00
+//  3: 01:27:30
+//  4: 01:50:00
+//  5: 02:12:30
+//  6: 02:35:00
+//  7: 02:57:30
+//  8: 03:20:00
+
+// Tests
+
+void IO_test_non_existent_file(void **state) {
+  int status;
+  int start_bin;
+  int num_integrations;
+
+  start_bin = -1;
+  num_integrations = -1;
+  status =
+      get_subs_from_datestrings("tests/bin/nonexistent", "2016-09-28T00:30:10",
+                                NULL, &start_bin, &num_integrations);
+  assert_int_equal(status, -1);
+  assert_int_equal(start_bin, -1);
+  assert_int_equal(num_integrations, -1);
+}
+
+void IO_test_only_start_time_int(void **state) {
+  int status;
+  int start_bin;
+  int num_integrations;
+
+  // Date before bin, so start at 0
+  start_bin = -1;
+  num_integrations = 3600;
+  status =
+      get_subs_from_datestrings("tests/bin/t10_n120_32", "2016-09-28T00:10:20",
+                                NULL, &start_bin, &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 0);
+  assert_int_equal(num_integrations, 3600);
+
+  // Start somewhere inside the bins aligned on start of bin
+  start_bin = -1;
+  num_integrations = 42;
+  status =
+      get_subs_from_datestrings("tests/bin/t10_n120_32", "2016-09-28T01:00:00",
+                                NULL, &start_bin, &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 2);
+  assert_int_equal(num_integrations, 42);
+
+  // Start somewhere inside the bins
+  start_bin = -1;
+  num_integrations = 3;
+  status =
+      get_subs_from_datestrings("tests/bin/t10_n120_32", "2016-09-28T01:30:00",
+                                NULL, &start_bin, &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 3);
+  assert_int_equal(num_integrations, 3);
+
+  start_bin = -1;
+  num_integrations = 42;
+  status =
+      get_subs_from_datestrings("tests/bin/t10_n120_32", "2016-09-28T02:30:00",
+                                NULL, &start_bin, &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 6);
+  assert_int_equal(num_integrations, 42);
+}
+
+void IO_test_only_end_time_int(void **state) {
+  int status;
+  int start_bin;
+  int num_integrations;
+
+  // End somewhere inside the bins aligned on start of bin
+  start_bin = 0;
+  num_integrations = -1;
+  status = get_subs_from_datestrings("tests/bin/t10_n120_32", NULL,
+                                     "2016-09-28T01:00:00", &start_bin,
+                                     &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 0);
+  assert_int_equal(num_integrations, 360);
+
+  // End somewhere inside the bins
+  start_bin = 1;
+  num_integrations = -1;
+  status = get_subs_from_datestrings("tests/bin/t10_n120_32", NULL,
+                                     "2016-09-28T01:04:00", &start_bin,
+                                     &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 1);
+  assert_int_equal(num_integrations, 240);
+
+  start_bin = 3;
+  num_integrations = -1;
+  status = get_subs_from_datestrings("tests/bin/t10_n120_32", NULL,
+                                     "2016-09-28T01:30:00", &start_bin,
+                                     &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 3);
+  assert_int_equal(num_integrations, 120);
+
+  // End after last bin, update number of integrations to end of file
+  start_bin = 6;
+  num_integrations = 3600;
+  status = get_subs_from_datestrings("tests/bin/t10_n120_32", NULL,
+                                     "2016-09-28T04:30:00", &start_bin,
+                                     &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 6);
+  assert_int_equal(num_integrations, 600);
+}
+
+void IO_test_only_start_time_char(void **state) {
+  int status;
+  int start_bin;
+  int num_integrations;
+
+  // Date before bin, so start at 0
+  start_bin = -1;
+  num_integrations = 3600;
+  status =
+      get_subs_from_datestrings("tests/bin/t15_n90_8", "2016-09-28T00:10:20",
+                                NULL, &start_bin, &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 0);
+  assert_int_equal(num_integrations, 3600);
+
+  // Start somewhere inside the bins aligned on start of bin
+  start_bin = -1;
+  num_integrations = 42;
+  status =
+      get_subs_from_datestrings("tests/bin/t15_n90_8", "2016-09-28T01:05:00",
+                                NULL, &start_bin, &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 2);
+  assert_int_equal(num_integrations, 42);
+
+  // Start somewhere inside the bins
+  start_bin = -1;
+  num_integrations = 3;
+  status =
+      get_subs_from_datestrings("tests/bin/t15_n90_8", "2016-09-28T01:30:05",
+                                NULL, &start_bin, &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 3);
+  assert_int_equal(num_integrations, 3);
+
+  start_bin = -1;
+  num_integrations = 42;
+  status =
+      get_subs_from_datestrings("tests/bin/t15_n90_8", "2016-09-28T02:30:00",
+                                NULL, &start_bin, &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 5);
+  assert_int_equal(num_integrations, 42);
+}
+
+void IO_test_only_end_time_char(void **state) {
+  int status;
+  int start_bin;
+  int num_integrations;
+
+  // End somewhere inside the bins aligned on start of bin
+  start_bin = 0;
+  num_integrations = -1;
+  status = get_subs_from_datestrings("tests/bin/t15_n90_8", NULL,
+                                     "2016-09-28T01:05:00", &start_bin,
+                                     &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 0);
+  assert_int_equal(num_integrations, 270);
+
+  // End somewhere inside the bins
+  start_bin = 1;
+  num_integrations = 42;
+  status = get_subs_from_datestrings("tests/bin/t15_n90_8", NULL,
+                                     "2016-09-28T01:04:00", &start_bin,
+                                     &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 1);
+  assert_int_equal(num_integrations, 90);
+
+  start_bin = 3;
+  num_integrations = 0;
+  status = get_subs_from_datestrings("tests/bin/t15_n90_8", NULL,
+                                     "2016-09-28T01:30:00", &start_bin,
+                                     &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 3);
+  assert_int_equal(num_integrations, 90);
+
+  // End after last bin, update number of integrations to end of file
+  start_bin = 6;
+  num_integrations = 3600;
+  status = get_subs_from_datestrings("tests/bin/t15_n90_8", NULL,
+                                     "2016-09-28T04:30:00", &start_bin,
+                                     &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 6);
+  assert_int_equal(num_integrations, 270);
+}
+
+void IO_test_both_start_and_stop_int(void **state) {
+  int status;
+  int start_bin;
+  int num_integrations;
+
+  // Start before and end after bin files
+  start_bin = 10;
+  num_integrations = 100;
+  status = get_subs_from_datestrings(
+      "tests/bin/t10_n120_32", "2016-09-28T00:00:00", "2016-09-28T03:50:00",
+      &start_bin, &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 00);
+  assert_int_equal(num_integrations, 1320);
+
+  // Start and end corresponds to bin files
+  start_bin = 10;
+  num_integrations = 100;
+  status = get_subs_from_datestrings(
+      "tests/bin/t10_n120_32", "2016-09-28T00:20:00", "2016-09-28T03:40:00",
+      &start_bin, &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 0);
+  assert_int_equal(num_integrations, 1320);
+
+  // Start and end inside bin
+  start_bin = 10;
+  num_integrations = 100;
+  status = get_subs_from_datestrings(
+      "tests/bin/t10_n120_32", "2016-09-28T00:30:00", "2016-09-28T03:30:00",
+      &start_bin, &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 0);
+  assert_int_equal(num_integrations, 1200);
+
+  start_bin = 10;
+  num_integrations = 100;
+  status = get_subs_from_datestrings(
+      "tests/bin/t10_n120_32", "2016-09-28T00:40:00", "2016-09-28T03:20:00",
+      &start_bin, &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 1);
+  assert_int_equal(num_integrations, 1080);
+
+  // Start and end inverted inside bin
+  start_bin = 10;
+  num_integrations = 100;
+  status = get_subs_from_datestrings(
+      "tests/bin/t10_n120_32", "2016-09-28T03:30:00", "2016-09-28T00:30:00",
+      &start_bin, &num_integrations);
+  assert_int_equal(status, -1);
+  assert_int_equal(start_bin, 9);
+  assert_int_equal(num_integrations, 100);
+}
+
+void IO_test_both_start_and_stop_char(void **state) {
+  int status;
+  int start_bin;
+  int num_integrations;
+
+  // Start before and end after bin files
+  start_bin = 10;
+  num_integrations = 100;
+  status = get_subs_from_datestrings(
+      "tests/bin/t15_n90_8", "2016-09-28T00:00:00", "2016-09-28T03:50:00",
+      &start_bin, &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 0);
+  assert_int_equal(num_integrations, 810);
+
+  // Start and end corresponds to bin files
+  start_bin = 10;
+  num_integrations = 100;
+  status = get_subs_from_datestrings(
+      "tests/bin/t15_n90_8", "2016-09-28T00:20:00", "2016-09-28T03:20:00",
+      &start_bin, &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 0);
+  assert_int_equal(num_integrations, 810);
+
+  // Start and end inside bin
+  start_bin = 10;
+  num_integrations = 100;
+  status = get_subs_from_datestrings(
+      "tests/bin/t15_n90_8", "2016-09-28T00:31:15", "2016-09-28T03:28:45",
+      &start_bin, &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 0);
+  assert_int_equal(num_integrations, 810);
+
+  start_bin = 10;
+  num_integrations = 100;
+  status = get_subs_from_datestrings(
+      "tests/bin/t15_n90_8", "2016-09-28T00:42:30", "2016-09-28T03:17:30",
+      &start_bin, &num_integrations);
+  assert_int_equal(status, 0);
+  assert_int_equal(start_bin, 1);
+  assert_int_equal(num_integrations, 630);
+
+  // Start and end inverted inside bin
+  start_bin = 10;
+  num_integrations = 100;
+  status = get_subs_from_datestrings(
+      "tests/bin/t15_n90_8", "2016-09-28T03:28:45", "2016-09-28T00:31:15",
+      &start_bin, &num_integrations);
+  assert_int_equal(status, -1);
+  assert_int_equal(start_bin, 8);
+  assert_int_equal(num_integrations, 100);
+}
+
+// Entry point to run all tests
+int run_io_tests() {
+  const struct CMUnitTest tests[] = {
+      cmocka_unit_test(IO_test_non_existent_file),
+      cmocka_unit_test(IO_test_only_start_time_int),
+      cmocka_unit_test(IO_test_only_end_time_int),
+      cmocka_unit_test(IO_test_only_start_time_char),
+      cmocka_unit_test(IO_test_only_end_time_char),
+      cmocka_unit_test(IO_test_both_start_and_stop_int),
+      cmocka_unit_test(IO_test_both_start_and_stop_char)
+  };
+
+  return cmocka_run_group_tests_name("IO", tests, NULL, NULL);
+}

--- a/tests/tests_rfio.h
+++ b/tests/tests_rfio.h
@@ -1,0 +1,14 @@
+#ifndef _TESTS_RFIO_H
+#define _TESTS_RFIO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int run_io_tests();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _TESTS_RFIO_H */


### PR DESCRIPTION
Done on PE0SAT's suggestion.

This is more convenient that to have to calculate the start bin and the number of iterations.

The first attempt was to only parse the header of the first bin and calculate the start bin. This worked fine in theory with perfect bins. Not with real bins with slight time drifts and frame drops.
A second attempt was to parse the header of all bins. This worked fine, ended up to be unusable slow on longer acquisitions.
Thus the current and third iterative attempt. It guesses the start bin by reading the header of the first bin, then iteratively reads the guessed bin's header and adjusts by doing a better guess. In practice it rarely needs more than 3 guesses. This makes it accurate and fast.

Instead of adding a test dataset for the unit tests, it generates the testdata on the first test run.